### PR TITLE
Comma as decimal separator instead of Period

### DIFF
--- a/src/main/resources/assets/energymeter/lang/en_us.json
+++ b/src/main/resources/assets/energymeter/lang/en_us.json
@@ -20,7 +20,7 @@
 
   "tooltip.energymeter.number": "Number Setting",
   "tooltip.energymeter.number_desc_1": "Defines if the formatting of the transfer rate should be short or long.",
-  "tooltip.energymeter.number_desc_2": "Only affects the number if it's more than 1.000 FE/t.",
+  "tooltip.energymeter.number_desc_2": "Only affects the number if it's more than 1,000 FE/t.",
 
   "tooltip.energymeter.mode": "Mode Setting",
   "tooltip.energymeter.mode_desc_1": "Defines the mode of the Energy Meter.",


### PR DESCRIPTION
## Proposed Changes
-Change period in "1,000 FE/t" to comma

## Additional Context
Since it's "en_us", comma as decimal separator commonly used, and period is for decimal point.