### PR TITLE
Fixed invalid tag for meter recipe

### DIFF
--- a/src/main/resources/data/energymeter/recipe/meter.json
+++ b/src/main/resources/data/energymeter/recipe/meter.json
@@ -16,7 +16,7 @@
       "item": "minecraft:redstone"
     },
     "g": {
-      "tag": "forge:glass_panes"
+      "tag": "c:glass_panes"
     },
     "o": {
       "item": "minecraft:observer"


### PR DESCRIPTION
<!--
Before you submit anything:
  1. Make sure whatever you submit isn't already submitted or implemented in a newer version.
  2. Follow our Code of Conduct!
  3. Follow our Contribution Guidelines!

Steps to submit a pull request:
  1. Provide a short and clear title above.
  2. Split your pull request in logical commits especially if you implemented multiple features or fixed multiple bugs!
  3. Unrelated features or bug fixes should be done in different pull requests.
  4. Keep the submission in English.

If the pull request doesn't fulfill our guidelines, it will be closed without any comment.
-->

## Proposed Changes
<!--
Please give us a basic overview of your changes here. You can add sub-lists to add more description.
-->
- fixed
  - the recipe of the energy meter caused uncraftable item on neoforge, since the tag forge:glass_panes does not exist there. Thus I switched it to c:glass_panes since this tag is present in 1.21 mod loaders (forge/neoforge)
https://docs.minecraftforge.net/en/latest/resources/server/tags/

> The common c namespaced tags seen in Forge are common across all loaders, however other loaders may have additional loader-specific tags under the same c namespace. When making a multi-loader mod, it is recommended to check the tags for each loader to ensure compatibility if you are considering a c tag you saw on other loaders that is missing in Forge. Loader-specific c tags may be in Forge under the forge namespace until they become common across all loaders.

<!-- 💚 Thank you for contributing! -->
